### PR TITLE
IOS now allow to stop background server with app terminate 

### DIFF
--- a/ios/Classes/BackgroundLocatorPlugin.m
+++ b/ios/Classes/BackgroundLocatorPlugin.m
@@ -80,6 +80,9 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
 -(void)applicationWillTerminate:(UIApplication *)application {
     [self observeRegionForLocation:_lastLocation];
+    if([PreferencesManager isStopWithTerminate]){
+        [self removeLocator];
+    }
 }
 
 - (void) observeRegionForLocation:(CLLocation *)location {
@@ -188,6 +191,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     CLLocationAccuracy accuracy = [Util getAccuracy:accuracyKey];
     double distanceFilter= [[settings objectForKey:kSettingsDistanceFilter] doubleValue];
     bool  showsBackgroundLocationIndicator=[[settings objectForKey:kSettingsShowsBackgroundLocationIndicator] boolValue];
+    bool  stopWithTerminate=[[settings objectForKey:kSettingsStopWithTerminate] boolValue];
 
     _locationManager.desiredAccuracy = accuracy;
     _locationManager.distanceFilter = distanceFilter;
@@ -201,6 +205,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     }
     
     [PreferencesManager saveDistanceFilter:distanceFilter];
+    [PreferencesManager setStopWithTerminate:stopWithTerminate];
 
     [PreferencesManager setCallbackHandle:callback key:kCallbackKey];
     
@@ -246,6 +251,10 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
 - (BOOL)isServiceRunning{
     return [PreferencesManager isServiceRunning];
+}
+
+- (BOOL)isStopWithTerminate{
+    return [PreferencesManager isStopWithTerminate];
 }
 
 @end

--- a/ios/Classes/Globals.h
+++ b/ios/Classes/Globals.h
@@ -48,6 +48,7 @@ FOUNDATION_EXPORT NSString *const kArgCallbackDispatcher;
 FOUNDATION_EXPORT NSString *const kSettingsAccuracy;
 FOUNDATION_EXPORT NSString *const kSettingsDistanceFilter;
 FOUNDATION_EXPORT NSString *const kSettingsShowsBackgroundLocationIndicator;
+FOUNDATION_EXPORT NSString *const kSettingsStopWithTerminate;
 
 FOUNDATION_EXPORT NSString *const kBCMSendLocation;
 FOUNDATION_EXPORT NSString *const kBCMInit;
@@ -55,6 +56,7 @@ FOUNDATION_EXPORT NSString *const kBCMDispose;
 
 FOUNDATION_EXPORT NSString *const kPrefObservingRegion;
 FOUNDATION_EXPORT NSString *const kPrefServiceRunning;
+FOUNDATION_EXPORT NSString *const kPrefStopWithTerminate;
 
 @end
 

--- a/ios/Classes/Globals.m
+++ b/ios/Classes/Globals.m
@@ -45,6 +45,7 @@ NSString *const kArgCallbackDispatcher = @"callbackDispatcher";
 NSString *const kSettingsAccuracy = @"settings_accuracy";
 NSString *const kSettingsDistanceFilter = @"settings_distanceFilter";
 NSString *const kSettingsShowsBackgroundLocationIndicator = @"settings_ios_showsBackgroundLocationIndicator";
+NSString *const kSettingsStopWithTerminate = @"settings_ios_stopWithTerminate";
 
 NSString *const kBCMSendLocation = @"BCM_SEND_LOCATION";
 NSString *const kBCMInit = @"BCM_INIT";
@@ -52,6 +53,7 @@ NSString *const kBCMDispose = @"BCM_DISPOSE";
 
 NSString *const kPrefObservingRegion = @"pref_observingRegion";
 NSString *const kPrefServiceRunning = @"pref_serviceRunning";
+NSString *const kPrefStopWithTerminate = @"pref_isStopWithTerminate";
 
 
 @end

--- a/ios/Classes/Preferences/PreferencesManager.h
+++ b/ios/Classes/Preferences/PreferencesManager.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isObservingRegion;
 + (void)setServiceRunning:(BOOL) running;
 + (BOOL)isServiceRunning;
++ (void)setStopWithTerminate:(BOOL) terminate;
++ (BOOL)isStopWithTerminate;
 
 @end
 

--- a/ios/Classes/Preferences/PreferencesManager.m
+++ b/ios/Classes/Preferences/PreferencesManager.m
@@ -64,4 +64,12 @@
     return [[NSUserDefaults standardUserDefaults] boolForKey:kPrefServiceRunning];
 }
 
++ (void)setStopWithTerminate:(BOOL)terminate {
+    [[NSUserDefaults standardUserDefaults] setBool:terminate forKey:kPrefStopWithTerminate];
+}
+
++ (BOOL)isStopWithTerminate {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kPrefStopWithTerminate];
+}
+
 @end

--- a/lib/keys.dart
+++ b/lib/keys.dart
@@ -59,6 +59,8 @@ class Keys {
 
   static const String SETTINGS_IOS_SHOWS_BACKGROUND_LOCATION_INDICATOR =
       'settings_ios_showsBackgroundLocationIndicator';
+  static const String SETTINGS_IOS_STOP_WITH_TERMINATE =
+      'settings_ios_stopWithTerminate';
 
   static const String BCM_SEND_LOCATION = 'BCM_SEND_LOCATION';
   static const String BCM_NOTIFICATION_CLICK = 'BCM_NOTIFICATION_CLICK';

--- a/lib/settings/ios_settings.dart
+++ b/lib/settings/ios_settings.dart
@@ -10,10 +10,13 @@ class IOSSettings extends LocatorSettings {
   /// [showsBackgroundLocationIndicator] The background location usage indicator is a blue bar or a blue pill in the status bar on iOS. Default is false.
 
   final bool showsBackgroundLocationIndicator;
+  final bool stopWithTerminate;
+  
   const IOSSettings({
     LocationAccuracy accuracy = LocationAccuracy.NAVIGATION,
     double distanceFilter = 0,
     this.showsBackgroundLocationIndicator = false,
+    this.stopWithTerminate = false,
   }) : super(accuracy: accuracy, distanceFilter: distanceFilter); //minutes
 
   Map<String, dynamic> toMap() {
@@ -22,6 +25,7 @@ class IOSSettings extends LocatorSettings {
       Keys.SETTINGS_DISTANCE_FILTER: distanceFilter,
       Keys.SETTINGS_IOS_SHOWS_BACKGROUND_LOCATION_INDICATOR:
           showsBackgroundLocationIndicator,
+      Keys.SETTINGS_IOS_STOP_WITH_TERMINATE: stopWithTerminate,
     };
   }
 }


### PR DESCRIPTION
iosSettings: IOSSettings(
            accuracy: locatorSetting.LocationAccuracy.NAVIGATION,
            distanceFilter: 100,
            stopWithTerminate: true),

I have added stopWithTerminate option in iOS setting by default it is false like default behaviour.

before merge my brach please test it :) 