### PR TITLE
Callback conversion fix for older devices

### DIFF
--- a/android/src/main/kotlin/yukams/app/background_locator_2/PreferencesManager.kt
+++ b/android/src/main/kotlin/yukams/app/background_locator_2/PreferencesManager.kt
@@ -25,9 +25,10 @@ class PreferencesManager {
             val sharedPreferences =
                     context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
 
+            val callback = map[Keys.ARG_CALLBACK] as Number
             sharedPreferences.edit()
                     .putLong(Keys.ARG_CALLBACK,
-                            map[Keys.ARG_CALLBACK] as Long)
+                            callback.toLong())
                     .apply()
 
             if (map[Keys.ARG_NOTIFICATION_CALLBACK] as? Long != null) {


### PR DESCRIPTION
One some older devices (guessing some 32bit androids) Dart callback does not come in form of a Long but is instead converted to another type (guessing an Int), causing the Kotlin code to break since .toLong() needs to be called and "as Long" does not work.

This PR fixed the upper issue.

Please review and merge.