### PR TITLE
fix for callback in release build

### DIFF
--- a/example/lib/location_callback_handler.dart
+++ b/example/lib/location_callback_handler.dart
@@ -4,6 +4,7 @@ import 'package:background_locator_2/location_dto.dart';
 
 import 'location_service_repository.dart';
 
+@pragma('vm:entry-point')
 class LocationCallbackHandler {
   static Future<void> initCallback(Map<dynamic, dynamic> params) async {
     LocationServiceRepository myLocationCallbackRepository =


### PR DESCRIPTION
fix for [ERROR:flutter/shell/common/shell.cc(93)] Dart Error: Dart_LookupLibrary: library 'package:untitled/location_callback_handler.dart' not found.
 By adding @pragma('vm:entry-point') before a class/ function, we let compiler know that the native code can access it