### PR TITLE
After flutter 3.10.0 sharedpreferecnces update

### DIFF
--- a/android/src/main/kotlin/yukams/app/background_locator_2/PreferencesManager.kt
+++ b/android/src/main/kotlin/yukams/app/background_locator_2/PreferencesManager.kt
@@ -25,11 +25,19 @@ class PreferencesManager {
             val sharedPreferences =
                     context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
 
-            val callback = map[Keys.ARG_CALLBACK] as Number
-            sharedPreferences.edit()
-                    .putLong(Keys.ARG_CALLBACK,
-                            callback.toLong())
-                    .apply()
+           
+
+        if(map[Keys.ARG_CALLBACK] as? Int != null) {
+                 val callback = map[Keys.ARG_CALLBACK] as Int
+print("int je")
+                sharedPreferences.edit()
+                        .putInt(Keys.ARG_CALLBACK,
+                                map[Keys.ARG_CALLBACK] as Int)
+                        .apply()
+        }
+        else {
+                print("nije int")
+        }
 
             if (map[Keys.ARG_NOTIFICATION_CALLBACK] as? Long != null) {
                 sharedPreferences.edit()
@@ -66,8 +74,8 @@ class PreferencesManager {
                     .apply()
 
             sharedPreferences.edit()
-                    .putLong(Keys.SETTINGS_ANDROID_NOTIFICATION_ICON_COLOR,
-                            settings[Keys.SETTINGS_ANDROID_NOTIFICATION_ICON_COLOR] as Long)
+                    .putInt(Keys.SETTINGS_ANDROID_NOTIFICATION_ICON_COLOR,
+                            settings[Keys.SETTINGS_ANDROID_NOTIFICATION_ICON_COLOR] as Int)
                     .apply()
 
             sharedPreferences.edit()

--- a/android/src/main/kotlin/yukams/app/background_locator_2/PreferencesManager.kt
+++ b/android/src/main/kotlin/yukams/app/background_locator_2/PreferencesManager.kt
@@ -23,21 +23,12 @@ class PreferencesManager {
         @JvmStatic
         fun saveSettings(context: Context, map: Map<Any, Any>) {
             val sharedPreferences =
-                    context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+                    context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)           
 
-           
-
-        if(map[Keys.ARG_CALLBACK] as? Int != null) {
-                 val callback = map[Keys.ARG_CALLBACK] as Int
-print("int je")
-                sharedPreferences.edit()
+       sharedPreferences.edit()
                         .putInt(Keys.ARG_CALLBACK,
                                 map[Keys.ARG_CALLBACK] as Int)
                         .apply()
-        }
-        else {
-                print("nije int")
-        }
 
             if (map[Keys.ARG_NOTIFICATION_CALLBACK] as? Long != null) {
                 sharedPreferences.edit()


### PR DESCRIPTION
I kept getting error regarding .toLong conversion while traying to save callback to sharedprefrences, so I have updated it to use .toInt conversion which seems to be working right now.