### PR TITLE
Add namespace to build.gradle to work with gradle versions >= 8.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,10 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
-
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'yukams.app.background_locator_2'
+    }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
As detailed here: [https://developer.android.com/build/configure-app-module#set-namespace](https://developer.android.com/build/configure-app-module#set-namespace), you now have to set the namespace in the build.gradle file. Specifying it in the android manifest is no longer enough.
The conditional is there, so older gradle versions (<4.2) are also supported.
Without this change, the plugin can no longer be used with an updated gradle plugin. 
This PR fixes #106 