### PR TITLE
Fix permission android (version < 6) and ios

### DIFF
--- a/android/src/main/kotlin/yukams/app/background_locator_2/BackgroundLocatorPlugin.kt
+++ b/android/src/main/kotlin/yukams/app/background_locator_2/BackgroundLocatorPlugin.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Process
 import android.os.Handler
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -80,10 +81,16 @@ class BackgroundLocatorPlugin
 
             val settings = args[Keys.ARG_SETTINGS] as Map<*, *>
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                    context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-                    == PackageManager.PERMISSION_DENIED) {
-
+//            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+//                    context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+//                    == PackageManager.PERMISSION_DENIED) {
+//
+//                val msg = "'registerLocator' requires the ACCESS_FINE_LOCATION permission."
+//                result?.error(msg, null, null)
+//                return
+//            }
+            if (context.checkPermission("android.permission.ACCESS_FINE_LOCATION", Process.myPid(), Process.myUid())
+                == PackageManager.PERMISSION_DENIED) {
                 val msg = "'registerLocator' requires the ACCESS_FINE_LOCATION permission."
                 result?.error(msg, null, null)
                 return
@@ -207,8 +214,7 @@ class BackgroundLocatorPlugin
             initializeService(context, args)
 
             val settings = args[Keys.ARG_SETTINGS] as Map<*, *>
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            if (context.checkPermission("Manifest.permission.ACCESS_FINE_LOCATION", Process.myPid(), Process.myUid())
                 == PackageManager.PERMISSION_GRANTED
             ) {
                 startIsolateService(context, settings)

--- a/android/src/main/kotlin/yukams/app/background_locator_2/IsolateHolderExtension.kt
+++ b/android/src/main/kotlin/yukams/app/background_locator_2/IsolateHolderExtension.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Process
 import android.util.Log
 import com.google.android.gms.location.LocationRequest
 import io.flutter.FlutterInjector
@@ -24,13 +25,11 @@ internal fun IsolateHolderService.startLocatorService(context: Context) {
     synchronized(serviceStarted) {
         this.context = context
         // resetting the background engine to avoid being stuck after an app crash
-        IsolateHolderService.backgroundEngine?.destroy();
+        IsolateHolderService.backgroundEngine?.destroy()
         IsolateHolderService.backgroundEngine = null
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED
-            ) {
+            if (context.checkPermission("android.permission.ACCESS_FINE_LOCATION", Process.myPid(), Process.myUid())
+                == PackageManager.PERMISSION_GRANTED) {
                 // We need flutter engine to handle callback, so if it is not available we have to create a
                 // Flutter engine without any view
                 Log.e("IsolateHolderService", "startLocatorService: Start Flutter Engine")
@@ -44,7 +43,7 @@ internal fun IsolateHolderService.startLocatorService(context: Context) {
                 val callbackInfo =
                     FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
 
-                if(callbackInfo == null) {
+                if (callbackInfo == null) {
                     Log.e("IsolateHolderExtension", "Fatal: failed to find callback");
                     return;
                 }
@@ -70,8 +69,7 @@ internal fun IsolateHolderService.startLocatorService(context: Context) {
                 Keys.BACKGROUND_CHANNEL_ID
             )
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            if (context.checkPermission("Manifest.permission.ACCESS_FINE_LOCATION", Process.myPid(), Process.myUid())
                 == PackageManager.PERMISSION_GRANTED
             ) {
                 backgroundChannel.setMethodCallHandler(this)

--- a/android/src/main/kotlin/yukams/app/background_locator_2/IsolateHolderService.kt
+++ b/android/src/main/kotlin/yukams/app/background_locator_2/IsolateHolderService.kt
@@ -5,6 +5,7 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.Process
 import android.os.Handler
 import android.os.IBinder
 import android.os.PowerManager
@@ -21,7 +22,6 @@ import yukams.app.background_locator_2.pluggables.InitPluggable
 import yukams.app.background_locator_2.pluggables.Pluggable
 import yukams.app.background_locator_2.provider.*
 import java.util.HashMap
-import androidx.core.app.ActivityCompat
 
 class IsolateHolderService : MethodChannel.MethodCallHandler, LocationUpdateListener, Service() {
     companion object {
@@ -140,8 +140,8 @@ class IsolateHolderService : MethodChannel.MethodCallHandler, LocationUpdateList
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.e("IsolateHolderService", "onStartCommand => intent.action : ${intent?.action}")
         if(intent == null) {
-            if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
-                || ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            if (context?.checkPermission("Manifest.permission.ACCESS_FINE_LOCATION", Process.myPid(), Process.myUid()) != PackageManager.PERMISSION_GRANTED
+                || context?.checkPermission("Manifest.permission.ACCESS_COARSE_LOCATION", Process.myPid(), Process.myUid()) != PackageManager.PERMISSION_GRANTED) {
                 Log.e("IsolateHolderService", "app has crashed, stopping it")
                 stopSelf()
             }


### PR DESCRIPTION
Hello,

I have made the following changes in this pull request:

- Updated the iOS code to first request `requestWhenInUseAuthorization` and then call `requestAlwaysAuthorization` to immediately obtain the `kCLAuthorizationStatusAuthorized` status.
- Replaced the `checkSelfPermission` method on Android with `checkPermission` since `checkSelfPermission` is only supported on Android SDK > 23.


