### PR TITLE
Adjust build.gradle for Android API 31 or higher compatibility and dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+* Fixed compatibility with Android Gradle Plugin 8.0+
+* Added namespace to Android build.gradle
+* Fixed JVM target compatibility between Java and Kotlin
+* Updated Gradle and Kotlin dependencies for better compatibility
+* Updated to target Android SDK 33
+* Removed namespace declaration from Android Manifest
+
 ## 2.0.6
 * Fixing iOS build
 * Fixing memory leak on Android

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a fork of the original background_locator_2 plugin with the following im
 - Updated Gradle and Kotlin dependencies
 - Added proper namespace to Android build.gradle
 
-### Usage with this fork
+## Usage with this fork
 
 To use this fork in your Flutter project, add the following to your `pubspec.yaml`:
 
@@ -26,6 +26,7 @@ dependencies:
     git:
       url: https://github.com/sultan18kh/background_locator_2_gradle_migration.git
       ref: fix/gradle-compatibility
+```
 
 ![demo](https://raw.githubusercontent.com/RomanJos/background_locator/master/demo.gif)
 
@@ -48,3 +49,4 @@ Thanks to all who contributed on this plugin to fix bugs and adding new feature,
 * [Gerardo Ibarra](https://github.com/gpibarra)
 * [RomanJos](https://github.com/RomanJos)
 * [Marcelo Henrique Neppel](https://github.com/marceloneppel)
+* [Sultan Khan](https://github.com/sultan18kh) (creator of fork)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,26 @@ This package is a V2 of the background_locator package, fixing it and making it 
 
 A Flutter plugin for getting location updates even when the app is killed.
 
+## Fork Information
+
+This is a fork of the original background_locator_2 plugin with the following improvements:
+
+- Added compatibility with Android Gradle Plugin 8.0+
+- Fixed JVM target compatibility issues
+- Updated Gradle and Kotlin dependencies
+- Added proper namespace to Android build.gradle
+
+### Usage with this fork
+
+To use this fork in your Flutter project, add the following to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  background_locator_2:
+    git:
+      url: https://github.com/sultan18kh/background_locator_2_gradle_migration.git
+      ref: fix/gradle-compatibility
+
 ![demo](https://raw.githubusercontent.com/RomanJos/background_locator/master/demo.gif)
 
 Refer to [wiki](https://github.com/Yukams/background_locator_fixed/wiki) page for install and setup instruction or jump to specific subject with below links:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ android {
     }
     
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_17
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,20 +5,19 @@ buildscript {
     ext.kotlin_version = '1.7.20'
     repositories {
         google()
-        jcenter()
+        mavenCentral()  // substitui jcenter() que foi descontinuado
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
-rootProject.allprojects {
+allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -28,23 +27,27 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'yukams.app.background_locator_2'
 
-    compileSdkVersion 33
+    compileSdkVersion 31  // o android:attr/lStar so existe do 31 em diante
+
+    defaultConfig {
+        minSdkVersion 19
+        targetSdkVersion 31 
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-    defaultConfig {
-        minSdkVersion 19
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
+
     lintOptions {
         disable 'InvalidPackage'
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    
+
     kotlinOptions {
         jvmTarget = '1.8'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,13 +28,13 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'yukams.app.background_locator_2'
 
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -41,8 +41,8 @@ android {
         disable 'InvalidPackage'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     
     kotlinOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -34,7 +34,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
@@ -46,7 +46,7 @@ android {
     }
     
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = '1.8'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,12 +41,12 @@ android {
         disable 'InvalidPackage'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,6 +26,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'yukams.app.background_locator_2'
+
     compileSdkVersion 29
 
     sourceSets {
@@ -36,6 +39,14 @@ android {
     }
     lintOptions {
         disable 'InvalidPackage'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="yukams.app.background_locator_2"></manifest>
+<manifest></manifest>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,9 @@
 name: background_locator_2
 description: A Flutter plugin to request the location even if the app is killed. Sending the location to a dart function in background, also provide a meter filter
-version: 2.0.6
-homepage: https://github.com/Yukams/background_locator_fixed
-issue_tracker: https://github.com/Yukams/background_locator_fixed/issues
+version: 2.0.7
+homepage: https://github.com/sultan18kh/background_locator_2_gradle_migration
+repository: https://github.com/sultan18kh/background_locator_2_gradle_migration
+issue_tracker: https://github.com/Yukams/background_locator_2_gradle_migration/issues
 platforms:
   android:
   ios:


### PR DESCRIPTION
Updated compileSdkVersion and targetSdkVersion to 31.

Fixed duplicated kotlin-gradle-plugin declaration.

Replaced jcenter() with mavenCentral() due to JCenter shutdown.

Kept support for Kotlin 1.7.20 and Gradle 7.3.0.

Tested versions:

- Flutter 3.29.3
- Dart 3.7.2
- Android Platform 35
- JDK 21

Successfully built release APK using `flutter build apk --release`.